### PR TITLE
Update Artist.ts

### DIFF
--- a/src/endpoints/Artist.ts
+++ b/src/endpoints/Artist.ts
@@ -39,7 +39,7 @@ export class Artist extends ReadWriteBaseClient {
    * https://developer.spotify.com/documentation/web-api/reference/get-an-artists-top-tracks
    */
   getArtistTopTracks(id: string, optionalParams?: GetMarketParams) {
-    return this.get<Tracks>(`/artist/${id}/top-tracks`, optionalParams);
+    return this.get<Tracks>(`/artists/${id}/top-tracks`, optionalParams);
   }
 
   /**


### PR DESCRIPTION
added the missing `s` to the endpoint as it was coming back as "404 service not found" when fetch the top tracks from the artist's page.

citation:
https://developer.spotify.com/documentation/web-api/reference/get-an-artists-top-tracks