### PR TITLE
fixing the "getArtistTopTracks" endpoint

### DIFF
--- a/src/endpoints/Artist.ts
+++ b/src/endpoints/Artist.ts
@@ -39,7 +39,7 @@ export class Artist extends ReadWriteBaseClient {
    * https://developer.spotify.com/documentation/web-api/reference/get-an-artists-top-tracks
    */
   getArtistTopTracks(id: string, optionalParams?: GetMarketParams) {
-    return this.get<Tracks>(`/artist/${id}/top-tracks`, optionalParams);
+    return this.get<Tracks>(`/artists/${id}/top-tracks`, optionalParams);
   }
 
   /**

--- a/tests/endpoints/Artist.test.ts
+++ b/tests/endpoints/Artist.test.ts
@@ -88,7 +88,7 @@ describe('Artist', () => {
 
       const result = await artist.getArtistTopTracks(mockArtistId, mockOptionalParams);
 
-      expect(artist['get']).toHaveBeenCalledWith('/artist/1234/top-tracks', mockOptionalParams);
+      expect(artist['get']).toHaveBeenCalledWith('/artists/1234/top-tracks', mockOptionalParams);
       expect(result).toEqual(mockResponse);
     });
   });


### PR DESCRIPTION
#52 

adding the missing s to the main endpoint and the endpoint in the test case as it was coming back as "404 service not found" when fetch the top tracks from the artist's page.

citation:
https://developer.spotify.com/documentation/web-api/reference/get-an-artists-top-tracks